### PR TITLE
only show connection info log once per function call

### DIFF
--- a/software/source/clients/base_device.py
+++ b/software/source/clients/base_device.py
@@ -251,6 +251,7 @@ class Device:
             await asyncio.sleep(0.01)
 
     async def websocket_communication(self, WS_URL):
+        show_connection_log = True
         while True:
             try:
                 async with websockets.connect(WS_URL) as websocket:
@@ -306,7 +307,9 @@ class Device:
                                 send_queue.put(result)
             except:
                 logger.debug(traceback.format_exc())
-                logger.info(f"Connecting to `{WS_URL}`...")
+                if show_connection_log:
+                  logger.info(f"Connecting to `{WS_URL}`...")
+                  show_connection_log = False
                 await asyncio.sleep(2)
 
     async def start_async(self):


### PR DESCRIPTION
### Description

The code changes in this pull request include updating the `base_device.py` file within the `source/clients` directory. The modifications consist of introducing a new variable `show_connection_log` to control logging messages when connecting to a WebSocket URL.

Changes:
- Introduced a new boolean variable `show_connection_log` with a default value of `True`.
- Added a condition to log the connection attempt to a WebSocket URL only if `show_connection_log` is `True`. After the initial log, the variable is set to `False` to prevent repetitive logging.
- The intention behind this change is to log the connection message only once per connection attempt to reduce unnecessary logs.

These changes enhance the logging behavior when connecting to WebSocket URLs in the `websocket_communication` method of the `BaseDevice` class.